### PR TITLE
added retry limit, the default was changed to 20

### DIFF
--- a/cmd/cmd_utils.go
+++ b/cmd/cmd_utils.go
@@ -137,7 +137,7 @@ func InitTFAConfigFile(viper *viper.Viper) {
 	common.HandleError(err, "nopanic")
 	viper.SetConfigType("ini")
 	viper.SetDefault("config.concurrency", true)
-	viper.SetDefault("config.retry_times", 1)
+	viper.SetDefault("config.retry_times", 20)
 	viper.SetDefault("config.add_attributes", false)
 	err = viper.ReadConfig(bytes.NewBuffer(file))
 	common.HandleError(err, "nopanic")

--- a/core/tfacon.go
+++ b/core/tfacon.go
@@ -34,7 +34,15 @@ func Run(viperRun, viperConfig *viper.Viper) {
 	var con TFACon = GetCon(viperRun)
 
 	con.InitConnector()
-	runHelper(viperConfig, con.GetAllTestIds(), con, "run")
+	ids := con.GetAllTestIds()
+	retry := viperConfig.GetInt("config.retry_times")
+	original_retry := retry
+	for len(ids) != 0 && retry > 0 {
+		runHelper(viperConfig, ids, con, "run")
+		ids = con.GetAllTestIds()
+		fmt.Printf("This is the %d retry\n", original_retry-retry+1)
+		retry--
+	}
 }
 
 func runHelper(viperConfig *viper.Viper, ids []string, con TFACon, operation string) {
@@ -55,7 +63,6 @@ func runHelper(viperConfig *viper.Viper, ids []string, con TFACon, operation str
 	}
 	// Doing this because the api can only take 20 items per request
 	con.UpdateAll(updated_list_of_issues, viperConfig.GetBool("config.verbose"))
-	runHelper(viperConfig, con.GetAllTestIds(), con, operation)
 }
 
 // GetInfo method is the get info operation for any type of connector that


### PR DESCRIPTION
User now can define retry_times under tfacon.cfg to define how many times tfacon retry if anything fails