### PR TITLE
added panic from the caller level

### DIFF
--- a/core/tfacon.go
+++ b/core/tfacon.go
@@ -43,6 +43,9 @@ func Run(viperRun, viperConfig *viper.Viper) {
 		fmt.Printf("This is the %d retry\n", original_retry-retry+1)
 		retry--
 	}
+	if len(con.GetAllTestIds()) != 0 {
+		panic("Update Failed, check the tfa-c/tfa-r service")
+	}
 }
 
 func runHelper(viperConfig *viper.Viper, ids []string, con TFACon, operation string) {


### PR DESCRIPTION
There should still be a panic mechanism so customer can know that tfacon failed, it should sit outside of all goroutines, so it can be recovered later