### PR TITLE
Add auto finalized in comment

### DIFF
--- a/connectors/rp_connector.go
+++ b/connectors/rp_connector.go
@@ -286,6 +286,7 @@ func (c *RPConnector) BuildIssueItemHelper(id string, tfaConfig common.TFAConfig
 			predictionCode := common.TFADefectType[prediction]["locator"]
 			issueInfo.IssueType = predictionCode
 			log.Printf("Finalizer prediction code is: %s\n", predictionCode)
+			issueInfo.Comment = "### TFA-C Auto Finalized\n" + issueInfo.Comment
 		} else {
 			log.Println("The predictions were not extracted correctly, so no finalizer update will be made!")
 		}


### PR DESCRIPTION
Add the finalized info the issue description comment, which could be used to identify the TFA-C auto finalized status.